### PR TITLE
fix bug with "center" attribute for panels in LISP and Perl

### DIFF
--- a/widgets/panel/lisp_codegen.py
+++ b/widgets/panel/lisp_codegen.py
@@ -56,7 +56,7 @@ class LispPanelGenerator(wcodegen.LispWidgetCodeWriter):
 
     def get_layout_code(self, obj):
         ret = ['(wxPanel_layout (slot-%s self))\n' % self.codegen._format_name(obj.name)]
-        if obj.centered:
+        if "centered" in obj.properties and obj.centered:
             ret.append('(wxPanel_Centre (slot-top-window obj) wxBOTH)\n')
         return ret
 

--- a/widgets/panel/perl_codegen.py
+++ b/widgets/panel/perl_codegen.py
@@ -70,7 +70,7 @@ class PerlPanelGenerator(wcodegen.PerlWidgetCodeWriter):
 
     def get_layout_code(self, obj):
         ret = ['$self->Layout();\n']
-        if obj.centered:
+        if "centered" in obj.properties and obj.centered:
             ret.append('$self->Centre();\n')
         return ret
 


### PR DESCRIPTION
I found this difference in the code generation for panels, in LISP and Perl
I just copied the corresponding line from `widgets/panel/codegen.py`.