### PR TITLE
Allow PEP 3107 function annotations

### DIFF
--- a/codegen/py_codegen.py
+++ b/codegen/py_codegen.py
@@ -41,7 +41,7 @@ class SourceFileContent(BaseSourceFileContent):
         r'^\s+'                                            # leading spaces (mandatory)
         r'def\s+(?P<handler>[A-Za-z_]+\w*)'                # event handler name
         r'\s*'                                             # optional spaces
-        r'\(.*\):'                                         # function parameters
+        r'\(.*\)(?:\s*->\s*None)*:'                              # function parameters and optional PEP 3107 -- Function Annotations 
         r'\s*'                                             # optional spaces
         r'#\s*wxGlade:\s*(?P<class>\w+)\.<event_handler>'  # wxGlade event handler statement with class name
         r'\s*$' )                                          # tailing spaces


### PR DESCRIPTION
Allow the user to add [function annotations](https://www.python.org/dev/peps/pep-3107/), currently they are removed by wxGlade's codegen:

    def OnButtonHelp(self, event: wx.Event) -> None:  # wxGlade: FindFilesDialog.<event_handler>
        pass

will be overwritten by

    def OnButtonHelp(self, event: wx.Event):  # wxGlade: FindFilesDialog.<event_handler>
        pass

I have modified `rec_event_handler` to support this.

Would you be interested in generating PEP 3107 functions in the first place (should be user configurable)?