### PR TITLE
don't generate trailing whitespaces

### DIFF
--- a/codegen/py_codegen.py
+++ b/codegen/py_codegen.py
@@ -280,7 +280,7 @@ from %(top_win_module)s import %(top_win_class)s\n\n"""
     def generate_code_ctor(self, code_obj, is_new, tab):
         # generate code for the class constructor, including all children
         code_lines = []
-        write = code_lines.append
+        write = lambda s: code_lines.append(s if s.strip() else '\n')
 
         builder = self.obj_builders[code_obj.WX_CLASS]
         mycn = getattr(builder, 'cn', self.cn)


### PR DESCRIPTION
The generated python code contains empty lines consisting of spaces followed by `\n`, which upsets pylint (trailing whitespaces) - see attached image. 

The modification replaces these with a single `\n`.

![whitespace](https://user-images.githubusercontent.com/11137936/81476461-5d439c00-9212-11ea-8550-8d3089cdf679.jpg)

