### PR TITLE
Reducde the number of messages that are shown when generating code.

### DIFF
--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -1080,6 +1080,8 @@ class BaseLangCodeWriter(wcodegen.BaseCodeWriter):
                 # this isn't necessarily a bad error
                 self.warning(_('Changing permission of file "%s" failed: %s') % (filename, str(e)))
 
+        logging.info('Generated %s', filename)
+
     def store_as_attr(self, obj):
         """Returns True if 'obj' should be added as an attribute of its parent's class,
         False if it should be created as a local variable.

--- a/common.py
+++ b/common.py
@@ -89,7 +89,8 @@ def init_codegen():
 
 def load_code_writers():
     "Fills the common.code_writers dictionary: to do so, loads the modules found in the 'codegen/' subdir"
-    logging.info('Load code generators:')
+    if config.use_gui:
+        logging.info('Load code generators:')
     codegen_path = os.path.join(config.wxglade_path, 'codegen')
     sys.path.insert(0, codegen_path)
     for module in os.listdir(codegen_path):
@@ -129,7 +130,8 @@ def load_config():
 def load_sizers():
     """Load and initialise the sizer support modules into ordered dict instance.
     See edit_sizers.edit_sizers.init_all."""
-    logging.info('Load sizer generators:')
+    if config.use_gui:
+        logging.info('Load sizer generators:')
     for lang in code_writers.keys():
         module_name = 'edit_sizers.%s_sizers_codegen' % code_writers[lang].lang_prefix
         try:

--- a/log.py
+++ b/log.py
@@ -181,7 +181,10 @@ def init(filename='wxglade.log', encoding='utf-8', level=None):
 
     # instantiate console handler
     console_logger = logging.StreamHandler()
-    console_logger.setLevel(logging.INFO)
+    if config.debugging:
+        console_logger.setLevel(logging.DEBUG)
+    else:
+        console_logger.setLevel(logging.INFO)
     console_logger.setFormatter(default_formatter)
     logger.addHandler(console_logger)
 

--- a/plugins.py
+++ b/plugins.py
@@ -80,8 +80,6 @@ def load_widgets_from_dir(widget_dir, submodule='', default_section='not_set'):
     
             if config.use_gui and not submodule.endswith('codegen'):
                 logging.info('\t%s', module_name)
-            else:
-                logging.debug(_('Widget %s imported'), module_name)
     return buttons
 
 

--- a/wxglade.py
+++ b/wxglade.py
@@ -237,16 +237,16 @@ def _guiless_open_app(filename):
         common.root.filename = None
 
     end = time.time()
-    logging.info(_('Loading time: %.5f'), end - start)
+    logging.debug(_('Loading time: %.5f'), end - start)
 
     common.root.saved = True
     #common.property_panel.Raise()
 
     duration = end - start
     if filename:
-        logging.info( _("Loaded %s in %.2f seconds") % (os.path.basename(filename), duration ))
+        logging.debug( _("Loaded %s in %.2f seconds") % (os.path.basename(filename), duration ))
     else:
-        logging.info( _("Loaded in %.2f seconds") % duration )
+        logging.debug( _("Loaded in %.2f seconds") % duration )
 
     return True
 
@@ -297,27 +297,28 @@ def init_stage1(options):
     common.init_paths(options)
 
     # initialise own logging extensions
-    log.init(filename=config.log_file, encoding='utf-8', level='INFO')
+    log.init(filename=config.log_file, encoding='utf-8',
+             level='DEBUG' if config.debugging else 'INFO')
     atexit.register(log.deinit)
 
     # print versions
     logging.info( _('Starting wxGlade version "%s" on Python %s'), config.version, config.py_version )
 
     # print used paths
-    logging.info(_('Base directory:             %s'), config.wxglade_path)
-    logging.info(_('Documentation directory:    %s'), config.docs_path)
-    logging.info(_('Icons directory:            %s'), config.icons_path)
-    logging.info(_('Build-in widgets directory: %s'), config.widgets_path)
-    logging.info(_('Template directory:         %s'), config.templates_path)
-    logging.info(_('Credits file:               %s'), config.credits_file)
-    logging.info(_('License file:               %s'), config.license_file)
-    logging.info(_('Manual file:                %s'), config.manual_file)
-    logging.info(_('Tutorial file:              %s'), config.tutorial_file)
-    logging.info(_('Home directory:             %s'), config.home_path)
-    logging.info(_('Application data directory: %s'), config.appdata_path)
-    logging.info(_('Configuration file:         %s'), config.rc_file)
-    logging.info(_('History file:               %s'), config.history_file)
-    logging.info(_('Log file:                   %s'), config.log_file)
+    logging.debug(_('Base directory:             %s'), config.wxglade_path)
+    logging.debug(_('Documentation directory:    %s'), config.docs_path)
+    logging.debug(_('Icons directory:            %s'), config.icons_path)
+    logging.debug(_('Build-in widgets directory: %s'), config.widgets_path)
+    logging.debug(_('Template directory:         %s'), config.templates_path)
+    logging.debug(_('Credits file:               %s'), config.credits_file)
+    logging.debug(_('License file:               %s'), config.license_file)
+    logging.debug(_('Manual file:                %s'), config.manual_file)
+    logging.debug(_('Tutorial file:              %s'), config.tutorial_file)
+    logging.debug(_('Home directory:             %s'), config.home_path)
+    logging.debug(_('Application data directory: %s'), config.appdata_path)
+    logging.debug(_('Configuration file:         %s'), config.rc_file)
+    logging.debug(_('History file:               %s'), config.history_file)
+    logging.debug(_('Log file:                   %s'), config.log_file)
 
     # adapt application search path
     sys.path.insert(0, config.wxglade_path)


### PR DESCRIPTION
During testing, I execute `wxglade --generate-code` on a dozen or so files. Since `wxglade` is very verbose, lots of messages scroll by and it is hard to see if there is anything relevant.

This change reduces the number of message to 3 per file:
```
INFO    : Starting wxGlade version "0.9.9pre" on Python 3.8.2
INFO    : Read wxGlade project from file "test.wxg"
INFO    : Generated test.py
```
The last message was added, reporting the name of the file that was generated.

I did not delete any messages. I only downgraded them to be shown only in debug mode.

When running `wxglade` in GUI mode there are still lots of messages that show up. I think that these messages can also be downgraded.

