### PR TITLE
Check if output directory exists only when it is specified

### DIFF
--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -411,10 +411,11 @@ class BaseLangCodeWriter(wcodegen.BaseCodeWriter):
                 return "Output path is directory, not file"
             out_dir = os.path.dirname(out_dir)
 
-        if not os.path.isdir(out_dir):
-            return "Output directory does not exist"
-        if not os.access(out_dir, os.W_OK):
-            return "Output directory is not writable"
+        if out_dir:
+            if not os.path.isdir(out_dir):
+                return "Output directory does not exist"
+            if not os.access(out_dir, os.W_OK):
+                return "Output directory is not writable"
 
         # It's not possible to generate code from a template directly
         if self.is_template:


### PR DESCRIPTION
It is possible that no directory is indicated for the output file.
This is the case when launching wxGlade from the command line.

In such cases, the output directory is `None` or empty, and therefore it makes no sense to check for its existence.

The problem can be reproduced by issuing a command like:
```
$ wxglade -g XRC -o outfile.xrc infile.wxg
```