### PR TITLE
Check for existence of common.app_tree before attempting to remove widget's reference

### DIFF
--- a/edit_base.py
+++ b/edit_base.py
@@ -397,7 +397,8 @@ class EditBase(np.PropertyOwner):
 
         # remove from Tree (rebuild_tree to be called separately)
         if misc.focused_widget is self: misc.focused_widget = None
-        common.app_tree.remove(self)  # remove mutual reference from widget to/from Tree item
+        if common.app_tree is not None:
+            common.app_tree.remove(self)  # remove mutual reference from widget to/from Tree item
 
         # bookkeeping
         if not self.IS_TOPLEVEL and self.IS_NAMED and self.name:


### PR DESCRIPTION
When launching wxGlade from the command line, it is possible that the app tree gets "cleaned up" twice.

This patch fixes a problem on my own runs.
I must confess am not 100% sure about the cause of this problem, but this makes wxGlade work for me.

Please let me know if there is any other information I can provide, if this solution is not acceptable or incomplete.