### PR TITLE
wxPython 2.8 compatibility: SendSizeEventToParent and SetNativeFontInfo

### DIFF
--- a/compat.py
+++ b/compat.py
@@ -195,6 +195,27 @@ else:
         widget.Hide()
         wx.CallAfter(_Destroy, widget)
 
+def wxWindow_SendSizeEventToParent28(item, flags=0):
+    """\
+    Implementation of wxWindow.SendSizeEventToParent for wxPython 2.8
+
+    @param item:  Instance of wxWindow
+    @param flags: flags parameter for SendSizeEvent (ignored)
+    """
+    parent = item.GetParent()
+    if parent and not parent.IsBeingDeleted():
+        parent.SendSizeEvent()
+
+
+def wxWindow_SendSizeEventToParent3(item, flags=0):
+    """\
+    Wrapper of wxWindow.SendSizeEventToParent
+
+    @param item:  Instance of wxWindow
+    @param flags: flags parameter for SendSizeEvent
+    """
+    item.SendSizeEventToParent(flags)
+
 
 # Set different functions depending on the active wxPython version
 if wx.VERSION[:2] >= (2, 9):
@@ -202,11 +223,13 @@ if wx.VERSION[:2] >= (2, 9):
     GridSizer_GetCols = GridSizer_GetCols3
     SizerItem_SetWindow = SizerItem_AssignWindow
     wxWindow_IsEnabled = wxWindow_IsThisEnabled
+    wxWindow_SendSizeEventToParent = wxWindow_SendSizeEventToParent3
 else:
     GridSizer_GetRows = GridSizer_GetRows28
     GridSizer_GetCols = GridSizer_GetCols28
     SizerItem_SetWindow = SizerItem_SetWindow28
     wxWindow_IsEnabled = wxWindow_IsEnabled28
+    wxWindow_SendSizeEventToParent = wxWindow_SendSizeEventToParent28
 
 
 import wx.grid

--- a/edit_base.py
+++ b/edit_base.py
@@ -328,11 +328,11 @@ class EditBase(np.PropertyOwner):
         if not self.IS_SIZER: self.widget.SendSizeEvent()
         parent_window = self.parent_window
         parent_window.widget.SendSizeEvent()
-        if hasattr(self.widget, "SendSizeEventToParent") and wx.Platform == '__WXGTK__':
+        if hasattr(self.widget, "SendSizeEvent") and wx.Platform == '__WXGTK__':
             # following is required for gtk when e.g. pasting a button or label with non-standard font
             # on Windows or Mac Os it's not required
             wx.SafeYield()
-            self.widget.SendSizeEventToParent()
+            compat.wxWindow_SendSizeEventToParent(self.widget)
 
     # actual widget creation
     def create_widget(self):

--- a/edit_windows.py
+++ b/edit_windows.py
@@ -505,9 +505,14 @@ class WindowBase(EditBase):
     def _set_font(self):
         if not self.widget: return
         font_p = self.properties["font"]
-        if not font_p.is_active(): 
-            font = wx.Font()
-            font.SetNativeFontInfo( self._original["font"] )
+        if not font_p.is_active():
+            try:
+                font = wx.Font()
+                font.SetNativeFontInfo( self._original["font"] )
+            except TypeError:
+                # wxPython 2.8
+                font = self.widget.GetFont()
+                font.SetNativeFontInfoFromString( self._original["font"] )
         else:
             font = font_p.value
             families = np.FontProperty.font_families_to
@@ -568,9 +573,9 @@ class WindowBase(EditBase):
                 self.widget.Refresh()
             if "layout" in actions:
                 self.layout()
-            if "sizeevent" in actions and hasattr(self.widget, "SendSizeEventToParent"):
+            if "sizeevent" in actions:
                 wx.SafeYield()  # required for gtk when e.g. increasing the font size of a label or button
-                self.widget.SendSizeEventToParent()
+                compat.wxWindow_SendSizeEventToParent(self.widget)
         return actions
 
     def get_properties(self, without=set()):


### PR DESCRIPTION
Added compat.SendSizeEventToParent
Adapted SetNativeFontInfo call to wxPython 2.8