### PR TITLE
Enable parsing of python version 3.10+ in startup script

### DIFF
--- a/wxglade
+++ b/wxglade
@@ -38,7 +38,7 @@ for INTERPRETER in $INTERPRETER_LIST; do
   PYTHON_BIN=$INTERPRETER
 
   # determined current python version
-  PY_VERSION=$(${PYTHON_BIN} -c 'import re, sys; print(re.match(r"^([0-9]+.[0-9]+)", sys.version).group())')
+  PY_VERSION=$(${PYTHON_BIN} -c 'import platform; print(".".join(platform.python_version_tuple()[:2]))')
 
   EGG_DIR="wxGlade-${WXG_VERSION}-py${PY_VERSION}.egg"
 

--- a/wxglade
+++ b/wxglade
@@ -38,7 +38,7 @@ for INTERPRETER in $INTERPRETER_LIST; do
   PYTHON_BIN=$INTERPRETER
 
   # determined current python version
-  PY_VERSION=$(${PYTHON_BIN} -c 'import sys; print(sys.version[:3])')
+  PY_VERSION=$(${PYTHON_BIN} -c 'import re, sys; print(re.match(r"^([0-9]+.[0-9]+)", sys.version).group())')
 
   EGG_DIR="wxGlade-${WXG_VERSION}-py${PY_VERSION}.egg"
 


### PR DESCRIPTION
Previous code with [:3] was parsing 3.10 as 3.1 and not getting the
correct site-packages directory for launch

Fix #518