### PR TITLE
fix error C2466 when building empty choices with MSVC compilers

### DIFF
--- a/wcodegen/__init__.py
+++ b/wcodegen/__init__.py
@@ -789,7 +789,7 @@ class CppWidgetCodeWriter(CppMixin, BaseWidgetWriter):
                 self.tmpl_before.append( '%s%s,\n' % (self.codegen.tabs(1), choice) )
             self.tmpl_before.append('};\n')
         else:
-            self.tmpl_before.append('const wxString %(name)s_choices[] = {};\n')
+            self.tmpl_before.append('const wxString *%(name)s_choices = NULL;\n')
 
         return
 


### PR DESCRIPTION
Microsoft Visual Studio C++ compilers don't like empty arrays, see https://learn.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2466

This commit fixes this by instead representing an empty choice with NULL. This works on other platforms as well.

Tested with Visual Studio 16 2019, Visual Studio 17 2022 for Windows and g++ 10.2.1 for Linux.

Background: 
* I was trying to build my wxGlade-generated UI on Windows with Visual Studio and ran into "error C2466: cannot allocate an array of constant size 0", see https://github.com/bk138/multivnc/actions/runs/4854176864/jobs/8651217942#step:6:150 
* This did not happen back then with wxGlade v0.6 
* This change to wxGlade fixed it, see https://github.com/bk138/multivnc/commit/5d2fe8195ceb0e6e19abb91c3160d67ce8d21453