### PR TITLE
Fix version number in wxglade script

### DIFF
--- a/wxglade
+++ b/wxglade
@@ -14,7 +14,7 @@
 #  3. in a parallel Python module directory
 
 # Keep this up to date with version.py and sphinx/conf.py
-WXG_VERSION="1.1.0"
+WXG_VERSION="1.1.0a2"
 
 CURR_DIR=$(dirname "$0")
 


### PR DESCRIPTION
The `wxglade` shell script does not find the wxGlade installation otherwise.