### PR TITLE
Add Perl codegen support for wxStdDialogButtonSizer

### DIFF
--- a/codegen/perl_codegen.py
+++ b/codegen/perl_codegen.py
@@ -204,6 +204,7 @@ sub %(handler)s {
     tmpl_func_empty = '%(tab)sreturn;\n'
 
     tmpl_sizeritem = '%s->Add(%s, %s, %s, %s);\n'
+    tmpl_sizeritem_button = '%s->AddButton(%s);\n'
     tmpl_gridbagsizeritem = '%s->Add(%s, Wx::GBPosition->new%s, Wx::GBSpan->new%s, %s, %s);\n'
     tmpl_gridbagsizerspacer = '%s->Add(%s, %s, %s, %s, %s, %s);\n'
     tmpl_spacersize = '%s, %s'

--- a/edit_sizers/perl_sizers_codegen.py
+++ b/edit_sizers/perl_sizers_codegen.py
@@ -33,6 +33,10 @@ class PerlBoxSizerBuilder(BasePerlSizerBuilder):
     tmpl = '%(sizer_name)s = %(klass)s->new(%(orient)s);\n'
 
 
+class PerlStdDialogButtonSizerBuilder(BasePerlSizerBuilder):
+    tmpl = '%(sizer_name)s = %(klass)s->new();\n'
+
+
 class PerlWrapSizerBuilder(PerlBoxSizerBuilder):
     pass
 
@@ -57,6 +61,7 @@ class PerlGridBagSizerBuilder(PerlFlexGridSizerBuilder):
 def initialize():
     cn = common.class_names
     cn['EditBoxSizer'] = 'wxBoxSizer'
+    cn['EditStdDialogButtonSizer'] = 'wxStdDialogButtonSizer'
     cn['EditWrapSizer'] = 'wxWrapSizer'
     cn['EditStaticBoxSizer'] = 'wxStaticBoxSizer'
     cn['EditGridSizer'] = 'wxGridSizer'
@@ -67,6 +72,7 @@ def initialize():
     if plgen:
         awh = plgen.register_widget_code_generator
         awh('wxBoxSizer', PerlBoxSizerBuilder())
+        awh('wxStdDialogButtonSizer', PerlStdDialogButtonSizerBuilder())
         awh('wxWrapSizer', PerlWrapSizerBuilder())
         awh('wxStaticBoxSizer', PerlStaticBoxSizerBuilder())
         awh('wxGridSizer', PerlGridSizerBuilder())


### PR DESCRIPTION
Hello.  I use WxGlade with my Perl Wx projects.  Recently I had trouble adding a wxStdDialogButtonSizer; the code generation didn't work.  I found your advice to someone else here:  https://sourceforge.net/p/wxglade/mailman/wxglade-general/thread/CA%2BFnnTyNho1wXG0pvfF3W4683kMqnM9pLFXGaEcxpqawrfqVZw%40mail.gmail.com/  and was able to make similar changes to the Perl code generation.  I hope this contribution helps.
-- Eric Roode (aka Sue D. Nymme)