### PR TITLE
Allows translations to be viewed on Windows and macOS.

### DIFF
--- a/wxglade.py
+++ b/wxglade.py
@@ -53,7 +53,17 @@ if t.__class__ == gettext.NullTranslations:
     if sys.platform == "win32":
         lang = get_msw_locale_id()
         t = gettext.translation(
-            domain="wxglade", localedir='locale', languages=[lang], fallback=True)
+            domain="wxglade", localedir='locale', languages=[lang,], fallback=True)
+    if t.__class__ == gettext.NullTranslations:
+        current_locale = locale.getlocale()
+        if current_locale:
+            t = gettext.translation(
+                domain="wxglade", localedir='locale',
+                languages=[current_locale[0],], fallback=True)
+    if t.__class__ == gettext.NullTranslations:
+        print("Are you trying to boot from IDLE?"
+              " If so, after installing the necessary Python libraries,"
+              " try 'python3 -m idlelib.idle.'")
 t.install("wxglade")
 
 

--- a/wxglade.py
+++ b/wxglade.py
@@ -9,8 +9,7 @@ Entry point of wxGlade
 """
 
 import atexit
-import codecs
-import logging, os, sys, gettext, optparse
+import logging, os, sys, gettext, optparse, ctypes, locale
 
 # Use a NullWriter with Unicode support (encoding attribute) to catch and
 # drop all output in PyInstaller environment (standalone Edition)
@@ -32,7 +31,29 @@ if hasattr(sys, 'frozen') and not hasattr(sys.stderr, 'encoding'):
     sys.stderr = NullWriter()
 
 
-t = gettext.translation(domain="wxglade", localedir="locale", fallback=True)
+def get_msw_locale_id():
+    """Get UI language code string as locale.getlocale()
+
+    @return locale ID like "ja_JP".
+    On Windows, locale.getlocale() returns just "C" or None.
+    This causes gettext.translation() returns
+    gettext.NullTranslations object.
+
+    Use this function to get locale ID.
+    """
+    try:
+        locale_id = ctypes.windll.kernel32.GetUserDefaultUILanguage()
+        return locale.windows_locale[locale_id]
+    except:
+        return None
+
+
+t = gettext.translation(domain="wxglade", localedir='locale', fallback=True)
+if t.__class__ == gettext.NullTranslations:
+    if sys.platform == "win32":
+        lang = get_msw_locale_id()
+        t = gettext.translation(
+            domain="wxglade", localedir='locale', languages=[lang], fallback=True)
 t.install("wxglade")
 
 

--- a/wxglade.pyw
+++ b/wxglade.pyw
@@ -10,12 +10,8 @@ Entry point of wxGlade on windows
 """
 
 import sys, traceback
-import gettext
-t = gettext.translation(domain="wxglade", localedir="locale", fallback=True)
-t.install("wxglade")
-
-import config
 import wxglade
+import config
 
 msg   = u''  # Message to show in the message box (see {show_error_details())
 title = u''  # Title of the message box


### PR DESCRIPTION
In particular, the wxGlade translation was not showing up at all on Windows. This seems to be because Python's gettext module only looks at environment variables.

The same is true on macOS, but this one may have worked conventionally as well, depending on how wxGlade was activated.

In any case, it is not necessary to call install() in both wxglade.py and wxglade.pyw; it seems sufficient to call it only in the former.
